### PR TITLE
fix: resolve Perplexity iframe CSP frame-ancestors blocking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # PROJECT KNOWLEDGE BASE
 
-**Generated:** 2026-02-21 | **Commit:** 1ad51ad | **Branch:** feature/sidebar-panel
+**Generated:** 2026-02-22 | **Commit:** bdadc30 | **Branch:** feature/fix-perplexity-load
 
 > **IMMUTABLE SECTIONS**: The three CRITICAL sections below (PR Target Branch, No Autonomous Commits, English-Only Policy) **MUST NEVER be removed or modified.** They are project-level invariants that override all other directives.
 
@@ -49,7 +49,7 @@ All project communications — GitHub Issues, PRs, commit messages, code comment
 
 LLM Crosser is a Chrome extension (WXT + React 19 + Tailwind CSS v4) that embeds multiple LLM chat sites (ChatGPT, Gemini, Grok, Perplexity, Qwen, Z.ai) in iframes within a single tab. Users type once, query all simultaneously, and compare responses side-by-side.
 
-Key mechanism: `declarativeNetRequest` strips `X-Frame-Options`/CSP headers at network level; `frame-guard.content.ts` overrides `window.top`/`window.parent` at JS level to neutralize frame-busting scripts.
+Key mechanism: `declarativeNetRequest` strips `X-Frame-Options`/`Content-Security-Policy`/`Content-Security-Policy-Report-Only` headers at network level; `frame-guard.content.ts` overrides `window.top`/`window.parent` at JS level to neutralize frame-busting scripts.
 
 ## STRUCTURE
 
@@ -164,3 +164,6 @@ pnpm zip              # Package for Chrome Web Store
 - **Language persistence**: `AppLayout.tsx` syncs `i18n.changeLanguage()` with stored `settings.language` on mount via `useEffect`. Without this, page refresh reverts to fallback language (`en`).
 - **GitHub link**: Static link to repo in Sidebar footer, alongside existing "Report Issue" link. No API integration.
 - **Viral comparison examples**: 100 curated LLM comparison queries across 8 categories (Brain Teaser, AI Identity, Creative Writing, Coding Challenge, Practical Advice, Knowledge Test, Hot Take, Fun & Personality). Displayed randomly one-at-a-time in sidepanel via `ViralExampleCard`. Clicking "Try this" triggers `DETACH_BATCH_SEARCH` — reuses existing omnibox pipeline. Static data only, no API. `viral-comparison-examples.ts` is exempt from 200 LOC rule (static data, like `Icons.tsx`).
+ **DNR `requestDomains` must use apex domains**: Use `perplexity.ai` (not `www.perplexity.ai`) in `rules.json` `requestDomains`. Chrome DNR automatically matches all subdomains of listed domains, so apex domains provide the broadest coverage. Same applies to any future LLM site additions.
+ **Both apex and www domains configured for Perplexity**: `host_permissions`, `frame-src`, content script `matches`, and `web_accessible_resources` all include both `https://www.perplexity.ai/*` and `https://perplexity.ai/*` to handle potential redirects or domain variations.
+ **CSP-Report-Only also stripped**: `rules.json` removes both `content-security-policy` and `content-security-policy-report-only` response headers. Some sites (e.g., Perplexity behind Cloudflare) may send either or both.

--- a/entrypoints/AGENTS.md
+++ b/entrypoints/AGENTS.md
@@ -23,7 +23,7 @@ entrypoints/
 | ------------------------ | -------------- | ---------------- | ---------------------------------------------------------- |
 | `background.ts`          | Service worker | —                | Message hub, tab/omnibox/float management                  |
 | `frame-guard.content.ts` | **MAIN**       | `document_start` | Overrides `window.top`/`window.parent` before page JS runs |
-| `inject.content.ts`      | **ISOLATED**   | `document_idle`  | Registers message listeners, calls automation engine       |
+| `inject.content.ts`      | **ISOLATED**   | `document_start` | Registers message listeners, calls automation engine       |
 | `batch-search/main.tsx`  | Extension page | —                | React SPA rendered in a full tab                           |
 | `sidepanel/main.tsx`     | Extension page | —                | React SPA rendered in Chrome side panel                    |
 
@@ -51,7 +51,7 @@ Neutralizes frame-busting checks like `if (window.top !== window.self) { top.loc
 
 Must update `matches` array when adding a new LLM site.
 
-## inject.content.ts (112 LOC)
+## inject.content.ts (113 LOC)
 
 Dual-channel listener in ISOLATED world:
 

--- a/entrypoints/frame-guard.content.ts
+++ b/entrypoints/frame-guard.content.ts
@@ -8,6 +8,7 @@ export default defineContentScript({
     "https://chat.qwen.ai/*",
     "https://chat.z.ai/*",
     "https://www.perplexity.ai/*",
+    "https://perplexity.ai/*",
   ],
   allFrames: true,
   runAt: "document_start",

--- a/entrypoints/inject.content.ts
+++ b/entrypoints/inject.content.ts
@@ -19,6 +19,7 @@ export default defineContentScript({
     "https://chat.qwen.ai/*",
     "https://chat.z.ai/*",
     "https://www.perplexity.ai/*",
+    "https://perplexity.ai/*",
   ],
   allFrames: true,
   runAt: "document_start",

--- a/public/rules.json
+++ b/public/rules.json
@@ -14,6 +14,7 @@
       ],
       "responseHeaders": [
         { "header": "content-security-policy", "operation": "remove" },
+        { "header": "content-security-policy-report-only", "operation": "remove" },
         { "header": "x-frame-options", "operation": "remove" },
         { "header": "permissions-policy", "operation": "remove" },
         { "header": "cross-origin-resource-policy", "operation": "remove" },
@@ -29,7 +30,7 @@
         "grok.com",
         "chat.qwen.ai",
         "chat.z.ai",
-        "www.perplexity.ai"
+        "perplexity.ai"
       ],
       "resourceTypes": ["main_frame", "sub_frame"]
     }

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -41,10 +41,11 @@ export default defineConfig({
       "https://chat.qwen.ai/*",
       "https://chat.z.ai/*",
       "https://www.perplexity.ai/*",
+      "https://perplexity.ai/*",
     ],
     content_security_policy: {
       extension_pages:
-        "script-src 'self'; object-src 'self'; frame-src https://chatgpt.com https://gemini.google.com https://grok.com https://chat.qwen.ai https://chat.z.ai https://www.perplexity.ai;",
+        "script-src 'self'; object-src 'self'; frame-src https://chatgpt.com https://gemini.google.com https://grok.com https://chat.qwen.ai https://chat.z.ai https://www.perplexity.ai https://perplexity.ai;",
     },
     declarative_net_request: {
       rule_resources: [{ id: "ruleset_1", enabled: true, path: "rules.json" }],
@@ -60,6 +61,7 @@ export default defineConfig({
           "https://chat.qwen.ai/*",
           "https://chat.z.ai/*",
           "https://www.perplexity.ai/*",
+          "https://perplexity.ai/*",
         ],
       },
     ],


### PR DESCRIPTION
## Summary

- **Root cause**: `rules.json` `requestDomains` used `www.perplexity.ai` (subdomain) instead of `perplexity.ai` (apex). Chrome DNR only matches subdomains of listed domains, so the apex form provides broader coverage.
- Changed `requestDomains` to `perplexity.ai` and added `content-security-policy-report-only` to stripped response headers (Cloudflare may send either CSP variant).
- Added `perplexity.ai` (apex) alongside `www.perplexity.ai` to `host_permissions`, `frame-src`, content script `matches`, and `web_accessible_resources` for comprehensive domain coverage.
- Updated `AGENTS.md` files with DNR domain matching rules and CSP stripping documentation. Fixed `inject.content.ts` runAt docs (`document_idle` → `document_start`).

## Changed Files

| File | Change |
|---|---|
| `public/rules.json` | `requestDomains`: `www.perplexity.ai` → `perplexity.ai`; add `content-security-policy-report-only` removal |
| `wxt.config.ts` | Add `perplexity.ai` to `host_permissions`, `frame-src`, `web_accessible_resources` |
| `entrypoints/frame-guard.content.ts` | Add `https://perplexity.ai/*` to `matches` |
| `entrypoints/inject.content.ts` | Add `https://perplexity.ai/*` to `matches` |
| `AGENTS.md` | Add 3 notes on DNR domain rules + CSP-Report-Only stripping |
| `entrypoints/AGENTS.md` | Fix `inject.content.ts` runAt + LOC |

## Verification

- `pnpm build` passes ✓
- Built `manifest.json` and `rules.json` confirmed correct
- Playwright confirmed Perplexity response headers: `content-security-policy` with `frame-ancestors`, `x-frame-options: DENY`, `cross-origin-resource-policy: same-origin`