### PR TITLE
fix: gemini chat spinning issue

### DIFF
--- a/entrypoints/frame-guard.content.ts
+++ b/entrypoints/frame-guard.content.ts
@@ -46,5 +46,67 @@ export default defineContentScript({
         // Header-level stripping via declarativeNetRequest handles framing in that case.
       }
     }
+
+    // --- Quill injection handler (Gemini logged-in) ---
+    // ISOLATED world sends LLM_CROSSER_QUILL_INJECT via postMessage.
+    // MAIN world accesses Quill instance directly, injects text, and clicks send.
+    window.addEventListener("message", (event: MessageEvent) => {
+      if (event.data?.type !== "LLM_CROSSER_QUILL_INJECT") return;
+
+      const { text, requestId } = event.data as { text: string; requestId: string };
+
+      const reply = (success: boolean) =>
+        window.postMessage(
+          { type: "LLM_CROSSER_QUILL_INJECT_RESULT", requestId, success },
+          "*",
+        );
+
+      const container = document.querySelector(".ql-container") as HTMLElement | null;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const quill = (container as any)?.__quill as
+        | {
+          focus: () => void;
+          deleteText: (i: number, l: number, s: string) => void;
+          insertText: (i: number, t: string, s: string) => void;
+          getLength: () => number;
+          setSelection: (i: number) => void;
+        }
+        | undefined;
+
+      if (!quill) {
+        reply(false);
+        return;
+      }
+
+      quill.focus();
+      const len = quill.getLength();
+      if (len > 1) quill.deleteText(0, len, "user");
+      quill.insertText(0, text, "user");
+      quill.setSelection(quill.getLength() - 1);
+
+      // Poll for send button to become visible (Angular re-renders after Quill state change)
+      let attempts = 0;
+      const maxAttempts = 30;
+      const pollInterval = 100;
+
+      const poll = setInterval(() => {
+        attempts++;
+        const sendBtn = document.querySelector(
+          "button.send, .send-button-container button",
+        ) as HTMLButtonElement | null;
+
+        if (sendBtn && sendBtn.offsetParent !== null) {
+          clearInterval(poll);
+          sendBtn.click();
+          reply(true);
+          return;
+        }
+
+        if (attempts >= maxAttempts) {
+          clearInterval(poll);
+          reply(false);
+        }
+      }, pollInterval);
+    });
   },
 });

--- a/src/lib/quill-injection.ts
+++ b/src/lib/quill-injection.ts
@@ -1,0 +1,37 @@
+const QUILL_INJECT_TYPE = "LLM_CROSSER_QUILL_INJECT";
+const QUILL_RESULT_TYPE = "LLM_CROSSER_QUILL_INJECT_RESULT";
+const QUILL_TIMEOUT_MS = 5000;
+
+/**
+ * Attempts Quill-based text injection via MAIN world postMessage bridge.
+ * Used for Gemini's logged-in Quill editor where standard contenteditable
+ * manipulation fails to update Angular/Quill internal state.
+ *
+ * Returns true if the MAIN world handler successfully injected + submitted.
+ * Returns false if no Quill editor detected or injection failed.
+ */
+export function tryQuillInjection(query: string): Promise<boolean> {
+  const editor = document.querySelector(".ql-editor");
+  if (!editor) return Promise.resolve(false);
+
+  const requestId = `quill_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+
+  return new Promise<boolean>((resolve) => {
+    const timeout = setTimeout(() => {
+      window.removeEventListener("message", handler);
+      resolve(false);
+    }, QUILL_TIMEOUT_MS);
+
+    function handler(event: MessageEvent) {
+      if (event.data?.type !== QUILL_RESULT_TYPE || event.data?.requestId !== requestId) {
+        return;
+      }
+      clearTimeout(timeout);
+      window.removeEventListener("message", handler);
+      resolve(event.data.success === true);
+    }
+
+    window.addEventListener("message", handler);
+    window.postMessage({ type: QUILL_INJECT_TYPE, text: query, requestId }, "*");
+  });
+}


### PR DESCRIPTION
## Summary
- Fix Gemini chat spinning issue by enhancing frame-guard content script
- Add Quill editor injection support for proper text input handling
- Update inject.content.ts with improved message handling

## Changes
- `entrypoints/frame-guard.content.ts`: Enhanced frame-busting neutralization
- `entrypoints/inject.content.ts`: Improved content script messaging
- `src/lib/quill-injection.ts`: New Quill editor injection utility