### PR TITLE
fix: History page - site filter, timestamp tooltip, and site badges

### DIFF
--- a/src/components/history/HistorySearchCard.tsx
+++ b/src/components/history/HistorySearchCard.tsx
@@ -1,0 +1,58 @@
+import type { HistoryEntry } from "@/src/types/history";
+
+interface HistorySearchCardProps {
+  entry: HistoryEntry;
+  isFloatActive: boolean;
+  siteFilter: string | null;
+  onNavigate: (id: string) => void;
+  onSiteFilter: (siteName: string | null) => void;
+  getRelativeTime: (timestamp: number) => string;
+}
+
+export function HistorySearchCard({
+  entry,
+  isFloatActive,
+  siteFilter,
+  onNavigate,
+  onSiteFilter,
+  getRelativeTime,
+}: HistorySearchCardProps) {
+  return (
+    <div
+      onClick={() => !isFloatActive && onNavigate(entry.id)}
+      className={`p-3 bg-surface-secondary/50 hover:bg-surface-secondary border border-border/50 rounded-lg transition-all group ${!isFloatActive ? "cursor-pointer" : ""}`}
+    >
+      <div className="flex justify-between items-start gap-2">
+        <span className="font-medium text-sm text-text truncate flex-1">{entry.query}</span>
+        <span
+          className="text-xs text-text-secondary whitespace-nowrap"
+          title={new Date(entry.timestamp).toLocaleString()}
+        >
+          {getRelativeTime(entry.timestamp)}
+        </span>
+      </div>
+      {entry.siteResults.length > 0 && (
+        <div className="flex flex-wrap gap-1 mt-1.5">
+          {entry.siteResults.map((sr) => (
+            <button
+              key={sr.siteName}
+              onClick={(e) => {
+                e.stopPropagation();
+                onSiteFilter(siteFilter === sr.siteName ? null : sr.siteName);
+              }}
+              className={`text-[10px] px-1.5 py-0.5 rounded border transition-colors ${
+                siteFilter === sr.siteName
+                  ? "bg-primary/20 text-primary border-primary/30"
+                  : sr.conversationUrl
+                    ? "bg-success/10 text-success border-success/20 hover:bg-success/20"
+                    : "bg-surface text-text-secondary border-border hover:bg-surface-secondary"
+              }`}
+            >
+              {sr.siteName}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -70,7 +70,8 @@
     "sites": "Sites",
     "searchTab": "Search",
     "exportTab": "Export",
-    "exportEmpty": "No export history yet"
+    "exportEmpty": "No export history yet",
+    "filteredBy": "Filtered by"
   },
   "share": {
     "title": "Share Conversation",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -69,7 +69,8 @@
     "sites": "Sites",
     "searchTab": "Recherche",
     "exportTab": "Exportation",
-    "exportEmpty": "Aucun historique d'exportation"
+    "exportEmpty": "Aucun historique d'exportation",
+    "filteredBy": "Filtré par"
   },
   "share": {
     "title": "Partager la conversation",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -69,7 +69,8 @@
     "sites": "サイト",
     "searchTab": "検索",
     "exportTab": "エクスポート",
-    "exportEmpty": "エクスポート履歴がまだありません"
+    "exportEmpty": "エクスポート履歴がまだありません",
+    "filteredBy": "フィルター"
   },
   "share": {
     "title": "会話を共有",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -70,7 +70,8 @@
     "sites": "사이트",
     "searchTab": "검색",
     "exportTab": "내보내기",
-    "exportEmpty": "내보내기 기록이 없습니다"
+    "exportEmpty": "내보내기 기록이 없습니다",
+    "filteredBy": "필터"
   },
   "share": {
     "title": "대화 공유",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -69,7 +69,8 @@
     "sites": "Sites",
     "searchTab": "Busca",
     "exportTab": "Exportação",
-    "exportEmpty": "Nenhum histórico de exportação ainda"
+    "exportEmpty": "Nenhum histórico de exportação ainda",
+    "filteredBy": "Filtrado por"
   },
   "share": {
     "title": "Compartilhar Conversa",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -69,7 +69,8 @@
     "sites": "Сайты",
     "searchTab": "Поиск",
     "exportTab": "Экспорт",
-    "exportEmpty": "История экспорта пуста"
+    "exportEmpty": "История экспорта пуста",
+    "filteredBy": "Фильтр"
   },
   "share": {
     "title": "Поделиться беседой",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -69,7 +69,8 @@
     "sites": "网站",
     "searchTab": "搜索",
     "exportTab": "导出",
-    "exportEmpty": "还没有导出历史"
+    "exportEmpty": "还没有导出历史",
+    "filteredBy": "筛选"
   },
   "share": {
     "title": "分享对话",


### PR DESCRIPTION
## Summary

Fixes #11 — History page label click not tracking and UI improvements.

### Changes

- **Site badge click filters history**: Each history card now shows site result badges (from `siteResults`). Clicking a badge filters the list to entries that include that site. Toggle click to clear filter, or use the × button on the active filter indicator.
- **Precise timestamp on hover**: Relative time display (e.g. "5 minutes ago") now has a `title` tooltip showing the exact date/time via `toLocaleString()`.
- **Site status visualization**: Badges are color-coded — green for sites that responded (have `conversationUrl`), neutral for sites that were queried but have no response URL.

### Implementation

- Extracted `HistorySearchCard` component to `src/components/history/` (59 LOC) to keep `HistoryPage.tsx` under 200 LOC limit (now 191 LOC).
- Added `siteFilter` state with `useMemo` filtering integration.
- Added `history.filteredBy` i18n key to all 7 locales (en, ko, ja, zh, pt, ru, fr).
- Build passes with zero type errors.